### PR TITLE
fix: ingress packet drop issue for non-vpn-accessible services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
-CONTROLLER_TOOLS_VERSION ?= v0.11.1
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/internal/controller/service/controller.go
+++ b/internal/controller/service/controller.go
@@ -245,9 +245,11 @@ func (re *ReconcilerExtended) addFinalizer(ctx context.Context) (*ctrl.Result, e
 			if err := re.Client.Get(ctx, re.request.NamespacedName, re.service); err != nil {
 				return err
 			}
+
 			if controllerutil.ContainsFinalizer(re.service, consts.ServiceFinalizerString) {
 				return nil
 			}
+
 			controllerutil.AddFinalizer(re.service, consts.ServiceFinalizerString)
 
 			return re.Client.Update(ctx, re.service)
@@ -268,9 +270,11 @@ func (re *ReconcilerExtended) removeFinalizer(ctx context.Context) (*ctrl.Result
 			if err := re.Client.Get(ctx, re.request.NamespacedName, re.service); err != nil {
 				return err
 			}
+
 			if !controllerutil.ContainsFinalizer(re.service, consts.ServiceFinalizerString) {
 				return nil
 			}
+
 			controllerutil.RemoveFinalizer(re.service, consts.ServiceFinalizerString)
 
 			return re.Client.Update(ctx, re.service)

--- a/internal/controller/service/helpers.go
+++ b/internal/controller/service/helpers.go
@@ -51,17 +51,9 @@ var (
 
 // buildCNP builds and returns a CiliumNetworkPolicy struct based on the Service object.
 func (re *ReconcilerExtended) buildCNP() *ciliumv2.CiliumNetworkPolicy {
-	var fromEntities cilium_policy_api.EntitySlice
-
-	if re.service.Annotations["metallb.universe.tf/address-pool"] == "vpn-access" {
-		fromEntities = cilium_policy_api.EntitySlice{
-			cilium_policy_api.EntityCluster,
-			cilium_policy_api.EntityWorld,
-		}
-	} else {
-		fromEntities = cilium_policy_api.EntitySlice{
-			cilium_policy_api.EntityCluster,
-		}
+	fromEntities := cilium_policy_api.EntitySlice{
+		cilium_policy_api.EntityCluster,
+		cilium_policy_api.EntityWorld,
 	}
 
 	endpointSelectorLabelsMap := make(map[string]string, len(re.service.Spec.Selector))


### PR DESCRIPTION
This PR fixes an issue regarding packet drop in the ingress path caused by a missing entity in the CiliumNetworkPolicy.